### PR TITLE
New command for mining direction setting

### DIFF
--- a/main/java/net/ildar/wurm/bot/MinerBot.java
+++ b/main/java/net/ildar/wurm/bot/MinerBot.java
@@ -579,23 +579,11 @@ public class MinerBot extends Bot {
     private void sendMineActions(long tileId) {
         if (verbose) Utils.consolePrint("Mining tile " + tileId);
 
-        PlayerAction action;
-        switch (direction) {
-            case FORWARD: action = PlayerAction.MINE_FORWARD;
-                break;
-            case UPWARD: action = PlayerAction.MINE_UP;
-                break;
-            case DOWNWARD: action = PlayerAction.MINE_DOWN;
-                break;
-            default: action = PlayerAction.MINE_FORWARD;
-                break;
-        }
-
         for (int i = 0; i < clicks; i++)
             Mod.hud.getWorld().getServerConnection().sendAction(
                     pickaxe.getId(),
                     new long[]{tileId},
-                    action);
+                    direction.action);
     }
 
     private void handleStaminaThresholdChange(String input[]) {
@@ -718,7 +706,7 @@ public class MinerBot extends Bot {
         sft("Set a smelter fuelling timeout for smelting ores", "timeout(in milliseconds)"),
         sfn("Set a name for the fuel for smelting ores", "name"),
         v("Toggle the verbose mode. While verbose bot will show additional info in console", ""),
-        dir("Set mining direction. Possible directions are: f - forward, u - upward, d - downward. Forward is default direction.", "direction");
+        dir("Set mining direction. Possible directions are: f - forward, u - upward, d - downward. Forward is default direction. ", "direction");
 
         private String description;
         private String usage;
@@ -744,14 +732,17 @@ public class MinerBot extends Bot {
     }
 
     enum Directions {
-        UNKNOWN(""),
-        FORWARD("f"),
-        UPWARD("u"),
-        DOWNWARD("d");
+        UNKNOWN("", PlayerAction.MINE_FORWARD),
+        FORWARD("f", PlayerAction.MINE_FORWARD),
+        UPWARD("u", PlayerAction.MINE_UP),
+        DOWNWARD("d", PlayerAction.MINE_DOWN);
 
         String abbreviation;
-        Directions(String abbreviation) {
+        PlayerAction action;
+        Directions(String abbreviation, PlayerAction action)
+        {
             this.abbreviation = abbreviation;
+            this.action = action;
         }
 
         static Directions getByAbbreviation(String abbreviation) {

--- a/main/java/net/ildar/wurm/bot/MinerBot.java
+++ b/main/java/net/ildar/wurm/bot/MinerBot.java
@@ -9,7 +9,6 @@ import com.wurmonline.client.renderer.gui.*;
 import com.wurmonline.mesh.Tiles;
 import com.wurmonline.shared.constants.PlayerAction;
 import javafx.util.Pair;
-import net.ildar.wurm.Chat;
 import net.ildar.wurm.Mod;
 import net.ildar.wurm.Utils;
 import org.gotti.wurmunlimited.modloader.ReflectionUtil;
@@ -38,7 +37,7 @@ public class MinerBot extends Bot {
     private boolean verbose = false;
     private boolean noOre;
     private Random random = new Random();
-    private Directions direction = Directions.FORWARD;
+    private Direction direction = Direction.FORWARD;
 
     public MinerBot() {
         registerInputHandler(MinerBot.InputKey.s, this::handleStaminaThresholdChange);
@@ -320,8 +319,8 @@ public class MinerBot extends Bot {
             return;
         }
         
-        Directions newDirection = Directions.getByAbbreviation(input[0]);
-        if (newDirection == Directions.UNKNOWN) {
+        Direction newDirection = Direction.getByAbbreviation(input[0]);
+        if (newDirection == Direction.UNKNOWN) {
             printInputKeyUsageString(MinerBot.InputKey.dir);
             return;
         }
@@ -737,7 +736,7 @@ public class MinerBot extends Bot {
         }
     }
 
-    enum Directions {
+    enum Direction {
         UNKNOWN("", PlayerAction.MINE_FORWARD),
         FORWARD("f", PlayerAction.MINE_FORWARD),
         UPWARD("u", PlayerAction.MINE_UP),
@@ -745,16 +744,16 @@ public class MinerBot extends Bot {
 
         String abbreviation;
         PlayerAction action;
-        Directions(String abbreviation, PlayerAction action)
+        Direction(String abbreviation, PlayerAction action)
         {
             this.abbreviation = abbreviation;
             this.action = action;
         }
 
-        static Directions getByAbbreviation(String abbreviation) {
-            for(Directions directions : values())
-                if (directions.abbreviation.equals(abbreviation))
-                    return directions;
+        static Direction getByAbbreviation(String abbreviation) {
+            for(Direction direction : values())
+                if (direction.abbreviation.equals(abbreviation))
+                    return direction;
             return UNKNOWN;
         }
     }

--- a/main/java/net/ildar/wurm/bot/MinerBot.java
+++ b/main/java/net/ildar/wurm/bot/MinerBot.java
@@ -316,10 +316,10 @@ public class MinerBot extends Bot {
     private void handleDirectionChange(String[] input) {
         if (input == null || input.length != 1) {
             printInputKeyUsageString(MinerBot.InputKey.dir);
-            Utils.consolePrint("Current direction is \"" + direction.action + "\"");
+            printCurrentDirection();
             return;
         }
-
+        
         Directions newDirection = Directions.getByAbbreviation(input[0]);
         if (newDirection == Directions.UNKNOWN) {
             printInputKeyUsageString(MinerBot.InputKey.dir);
@@ -327,7 +327,11 @@ public class MinerBot extends Bot {
         }
 
         direction = newDirection;
-        Utils.consolePrint("Current direction is \"" + direction.action + "\"");
+        printCurrentDirection();
+    }
+
+    private void printCurrentDirection() {
+        Utils.consolePrint("Current direction is \"" + direction.abbreviation + "\"");
     }
 
     private void toggleVerboseMode() {

--- a/main/java/net/ildar/wurm/bot/MinerBot.java
+++ b/main/java/net/ildar/wurm/bot/MinerBot.java
@@ -316,6 +316,7 @@ public class MinerBot extends Bot {
     private void handleDirectionChange(String[] input) {
         if (input == null || input.length != 1) {
             printInputKeyUsageString(MinerBot.InputKey.dir);
+            Utils.consolePrint("Current direction is \"" + direction.action + "\"");
             return;
         }
 
@@ -326,6 +327,7 @@ public class MinerBot extends Bot {
         }
 
         direction = newDirection;
+        Utils.consolePrint("Current direction is \"" + direction.action + "\"");
     }
 
     private void toggleVerboseMode() {
@@ -706,7 +708,7 @@ public class MinerBot extends Bot {
         sft("Set a smelter fuelling timeout for smelting ores", "timeout(in milliseconds)"),
         sfn("Set a name for the fuel for smelting ores", "name"),
         v("Toggle the verbose mode. While verbose bot will show additional info in console", ""),
-        dir("Set mining direction. Possible directions are: f - forward, u - upward, d - downward. Forward is default direction. ", "direction");
+        dir("Set mining direction. Possible directions are: f - forward, u - upward, d - downward. Forward is default direction.", "direction");
 
         private String description;
         private String usage;


### PR DESCRIPTION
Была нужна возможность копать шахту не только прямо, но и вниз/вверх. Добавил боту команду "dir" с возможными значениями "f", "u", "d" (forward, upward и downward соответственно), устанавливающую направление. По умолчанию настройка имеет значение "f". Данная настройка будет действовать на все режимы работы бота.